### PR TITLE
fix: Remove duplicate imports

### DIFF
--- a/helios_data_analysis/data_analysis_22.py
+++ b/helios_data_analysis/data_analysis_22.py
@@ -1,9 +1,6 @@
 from db_analysis_utilities import *
 from analysis_functions import *
 
-from db_analysis_utilities import *
-from analysis_functions import *
-
 # specify the prefix for the plot files here. the plots will then be saved in the directory as mentioned below
 GLOBAL_PLOT_FILE_PREFIX = ""
 


### PR DESCRIPTION
Removes
```python
from db_analysis_utilities import *
from analysis_functions import *
```
being called twice.